### PR TITLE
Fix unsigned long long error on compile

### DIFF
--- a/bindings/pytorch/torchbind.cpp
+++ b/bindings/pytorch/torchbind.cpp
@@ -25,13 +25,13 @@ std::vector<torch::Tensor> attachState(torch::Tensor out){
     return {statexy, stateaa, statebb, statepp, statedd};
 }
 
-std::tuple<unsigned long long,unsigned long long> loadWrapper(const std::string& filename){
+std::tuple<int64_t, int64_t> loadWrapper(const std::string& filename){
     Rwkv.loadFile(filename);
 
     return std::make_tuple(Rwkv.num_layers, Rwkv.num_embed);
 }
 
-void cuda_rwkv_wrapper(unsigned long long token){
+void cuda_rwkv_wrapper(int64_t token){
     Rwkv.forward(token);
 }
 


### PR DESCRIPTION
Basically reverts torchbind changes from `fix 7b` commit